### PR TITLE
bintray is going away so don't use it in the future

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN \
 
 ARG SBT_VERSION
 RUN \
-  curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
-  dpkg -i sbt-$SBT_VERSION.deb && \
-  rm sbt-$SBT_VERSION.deb
+  curl -L "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" | tar zxf - -C /usr/share  && \
+  cd /usr/share/sbt/bin && \
+  rm sbt.bat sbtn-x86_64-apple-darwin sbtn-x86_64-pc-linux sbtn-x86_64-pc-win32.exe && \
+  ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
 ARG SCALA_VERSION
 RUN \


### PR DESCRIPTION
See notes on https://github.com/sbt/sbt/releases/tag/v1.4.8